### PR TITLE
add support for zig module

### DIFF
--- a/README.md
+++ b/README.md
@@ -196,16 +196,50 @@ git submodule update --remote
 
 ### Package Manager
 
-```zig
-exe.addModule("mailbox", b.dependency("mailbox", .{}).module("mailbox"));
+With an existing Zig project, adding Mailbox to it is easy:
+
+1. Add mailbox to your `build.zig.zon`
+2. Add mailbox to your `build.zig`
+
+To add mailbox to `build.zig.zon` simply run the following in your terminal:
+
+```sh
+cd my-example-project
+zig fetch --save=mailbox git+https://github.com/g41797/mailbox
 ```
 
-Zig Package Manager was changed and old installation instructions are based on addModule (see above)
-are wrong - [What happened to addModule?](https://ziggit.dev/t/what-happened-to-addmodule/2908)
+and in your `build.zig.zon` you should find a new dependency like:
 
-I'll add installation via package manager later, after testing.
+```zig
+.{
+    .name = "My example project",
+    .version = "0.0.1",
 
-Opened new issue [Fix installation instructions](https://github.com/g41797/mailbox/issues/2)
+    .dependencies = .{
+        .mailbox = .{
+            .url = "git+https://github.com/g41797/mailbox#3f794f34f5d859e7090c608da998f3b8856f8329",
+            .hash = "122068e7811ec1bfc2a81c9250078dd5dafa9dca4eb3f1910191ba060585526f03fe",
+        },
+    },
+    .paths = .{
+        "",
+    },
+}
+```
+
+Then, in your `build.zig`'s `build` function, add the following before
+`b.installArtifact(exe)`:
+
+```zig
+    const mailbox = b.dependency("mailbox", .{
+        .target = target,
+        .optimize = optimize,
+    });
+
+    exe.root_module.addImport("mailbox", mailbox.module("mailbox"));
+```
+
+From then on, you can use the Mailbox package in your project.
 
 ## Last warning
 First rule of multithreading:

--- a/build.zig
+++ b/build.zig
@@ -24,11 +24,16 @@ pub fn build(b: *std.Build) void {
         .optimize = optimize,
     });
 
+    _ = b.addModule("mailbox", .{
+        .root_source_file = b.path("src/mailbox.zig"),
+        .target = target,
+        .optimize = optimize,
+    });
+
     // This declares intent for the library to be installed into the standard
     // location when the user invokes the "install" step (the default step when
     // running `zig build`).
     b.installArtifact(lib);
-
 
     // Creates a step for unit testing. This only builds the test executable
     // but does not run it.


### PR DESCRIPTION
This commit will add support for Zig's `addModule`, allowing users to run:
```sh
zig fetch --save=mailbox git+https://github.com/g41797/mailbox
``` 
to add Mailbox as a dependency in `build.zig.zon`.

I also updated the README, "heavily inspired" by another fantastic project:
https://github.com/zigzap/zap
resolve #2 